### PR TITLE
练习pytorch框架模型的保存与加载并上传了vgg

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 dataset_CIFAR10/cifar-10-python.tar.gz filter=lfs diff=lfs merge=lfs -text
+vgg16_method.pth filter=lfs diff=lfs merge=lfs -text
+vgg16_method_2.pth filter=lfs diff=lfs merge=lfs -text

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.vscode-pylance"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "optim",
         "tensorboard",
+        "torchtyping",
         "torchvision"
     ]
 }

--- a/pytorch_course_11.ipynb
+++ b/pytorch_course_11.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 模型的保存与加载"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#导入第三方库\n",
+    "import torchvision, torch\n",
+    "from torch import nn\n",
+    "import torchtyping\n",
+    "from model_save import * "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vgg16 = torchvision.models.vgg16(weights= None)\n",
+    "#保存模型--方式1(保存模型结构+模型参数)\n",
+    "torch.save(vgg16, \"vgg16_method.pth\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VGG(\n",
+      "  (features): Sequential(\n",
+      "    (0): Conv2d(3, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (1): ReLU(inplace=True)\n",
+      "    (2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (3): ReLU(inplace=True)\n",
+      "    (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "    (5): Conv2d(64, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (6): ReLU(inplace=True)\n",
+      "    (7): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (8): ReLU(inplace=True)\n",
+      "    (9): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "    (10): Conv2d(128, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (11): ReLU(inplace=True)\n",
+      "    (12): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (13): ReLU(inplace=True)\n",
+      "    (14): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (15): ReLU(inplace=True)\n",
+      "    (16): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "    (17): Conv2d(256, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (18): ReLU(inplace=True)\n",
+      "    (19): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (20): ReLU(inplace=True)\n",
+      "    (21): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (22): ReLU(inplace=True)\n",
+      "    (23): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "    (24): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (25): ReLU(inplace=True)\n",
+      "    (26): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (27): ReLU(inplace=True)\n",
+      "    (28): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (29): ReLU(inplace=True)\n",
+      "    (30): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "  )\n",
+      "  (avgpool): AdaptiveAvgPool2d(output_size=(7, 7))\n",
+      "  (classifier): Sequential(\n",
+      "    (0): Linear(in_features=25088, out_features=4096, bias=True)\n",
+      "    (1): ReLU(inplace=True)\n",
+      "    (2): Dropout(p=0.5, inplace=False)\n",
+      "    (3): Linear(in_features=4096, out_features=4096, bias=True)\n",
+      "    (4): ReLU(inplace=True)\n",
+      "    (5): Dropout(p=0.5, inplace=False)\n",
+      "    (6): Linear(in_features=4096, out_features=1000, bias=True)\n",
+      "  )\n",
+      ")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\Administrator\\AppData\\Local\\Temp\\ipykernel_4784\\344919975.py:2: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.\n",
+      "  vgg16_model = torch.load(\"vgg16_method.pth\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "#加载模型方式1——>保存方式1\n",
+    "vgg16_model = torch.load(\"vgg16_method.pth\")\n",
+    "print(vgg16_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#保存方式2->保存网络模型中的参数为python中的字典形式(官方推荐的保存形式，占用的存储空间更小)\n",
+    "torch.save(vgg16.state_dict(), \"vgg16_method_2.pth\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VGG(\n",
+      "  (features): Sequential(\n",
+      "    (0): Conv2d(3, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (1): ReLU(inplace=True)\n",
+      "    (2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (3): ReLU(inplace=True)\n",
+      "    (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "    (5): Conv2d(64, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (6): ReLU(inplace=True)\n",
+      "    (7): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (8): ReLU(inplace=True)\n",
+      "    (9): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "    (10): Conv2d(128, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (11): ReLU(inplace=True)\n",
+      "    (12): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (13): ReLU(inplace=True)\n",
+      "    (14): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (15): ReLU(inplace=True)\n",
+      "    (16): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "    (17): Conv2d(256, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (18): ReLU(inplace=True)\n",
+      "    (19): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (20): ReLU(inplace=True)\n",
+      "    (21): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (22): ReLU(inplace=True)\n",
+      "    (23): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "    (24): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (25): ReLU(inplace=True)\n",
+      "    (26): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (27): ReLU(inplace=True)\n",
+      "    (28): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "    (29): ReLU(inplace=True)\n",
+      "    (30): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+      "  )\n",
+      "  (avgpool): AdaptiveAvgPool2d(output_size=(7, 7))\n",
+      "  (classifier): Sequential(\n",
+      "    (0): Linear(in_features=25088, out_features=4096, bias=True)\n",
+      "    (1): ReLU(inplace=True)\n",
+      "    (2): Dropout(p=0.5, inplace=False)\n",
+      "    (3): Linear(in_features=4096, out_features=4096, bias=True)\n",
+      "    (4): ReLU(inplace=True)\n",
+      "    (5): Dropout(p=0.5, inplace=False)\n",
+      "    (6): Linear(in_features=4096, out_features=1000, bias=True)\n",
+      "  )\n",
+      ")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\Administrator\\AppData\\Local\\Temp\\ipykernel_4784\\2346524202.py:3: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.\n",
+      "  vgg16.load_state_dict(torch.load(\"vgg16_method_2.pth\"))\n"
+     ]
+    }
+   ],
+   "source": [
+    "#加载方式2—> 保存方式2(默认加载只加载模型参数字典，如需加载网络结构需要新建网络结构)\n",
+    "vgg16 = torchvision.models.vgg16(weights= None)\n",
+    "vgg16.load_state_dict(torch.load(\"vgg16_method_2.pth\"))\n",
+    "# vgg16_model_dict = torch.load(\"vgg16_method_2.pth\")\n",
+    "# print(vgg16_model_dict) \n",
+    "print(vgg16)\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#陷阱->加载自己的网络模型时，需要将模型引入本文件中进行读取，添加from model_save指令即可，否则会报错\n",
+    "class Neural(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(Neural, self).__init__()  \n",
+    "        self.conv1 = nn.Conv2d()\n",
+    "    def forward(self, x):\n",
+    "        x = self.conv1(x)\n",
+    "        return x\n",
+    "\n",
+    "neural = Neural()\n",
+    "torch.save(neural, \"neural.pth\")\n",
+    "model = torch.load(\"neural.pth\")\n",
+    "print(model)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.19"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/vgg16_method.pth
+++ b/vgg16_method.pth
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc83232aaf3615a2dd988963eb965dce6e04079f6d7cf1b3c0e4bd810f5f834f
+size 553451562

--- a/vgg16_method_2.pth
+++ b/vgg16_method_2.pth
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:180190a9698b3efc466f1594e8e322a27d3f9430f05f1960d026babbe711b2e9
+size 553441586


### PR DESCRIPTION
1.学习在pytorch框架下使用基准模型的保存与加载，在本地测试了vgg16模型的此项功能，尤其注意官方推荐的state_dict()方法，此项方法仅保存模型的参数为一个字典到本地文件，可以节省模型的内存占用，加载模型时需要使用load_state_dict()方法，例：vgg16.load_state_dict(torch.load("vgg16_method_2.pth"))；另外，在本地加载自己的模型时，推荐在网络模型搭建完毕后直接保存在本地，需要引用时导入from model_save import *，这样即使模型不在当前文件中也能正确加载。